### PR TITLE
Add DALL-E mini support for `Image Prompt` mode

### DIFF
--- a/img_styler/configs/settings.toml
+++ b/img_styler/configs/settings.toml
@@ -5,6 +5,8 @@ TempDir = "var/lib/tmp/output"
 modelDir = "var/lib/pretrained_models"
 modelSupported = ['ffhq.pkl']
 SDVersion = "./models/stable-diffusion-v1-5"
+DALLEMini = "./models/dalle-mini"
+VQGAN = "./models/vqgan_imagenet_f16_16384"
 
 [Scheduler]
 JobDir = "var/lib/tmp/jobs"

--- a/img_styler/image_prompt/dalle_mini_model.py
+++ b/img_styler/image_prompt/dalle_mini_model.py
@@ -1,0 +1,97 @@
+# Reference: https://colab.research.google.com/github/borisdayma/dalle-mini/blob/main/tools/inference/inference_pipeline.ipynb#scrollTo=sOtoOmYsSYPz
+
+import os
+import numpy as np
+import random
+from PIL import Image
+import jax
+import jax.numpy as jnp
+from dalle_mini import DalleBart, DalleBartProcessor
+from vqgan_jax.modeling_flax_vqgan import VQModel
+from loguru import logger
+
+
+class DalleMini:
+    def __init__(self, model_path, vqgan_path):
+        logger.debug("Initializing models...")
+        # Define models
+        self.model, self.params = DalleBart.from_pretrained(
+            model_path, revision=None, dtype=jnp.float16, _do_init=False
+        )
+        logger.debug("DALL-E mini model initialized.")
+
+        self.processor = DalleBartProcessor.from_pretrained(model_path, revision=None)
+        logger.debug("DALL-E Processor model initialized.")
+
+        self.vqgan, self.vqgan_params = VQModel.from_pretrained(
+            vqgan_path, revision="e93a26e7707683d349bf5d5c41c5b0ef69b677a9", _do_init=False
+        )
+        logger.debug("VQGAN model initialized.")
+
+        # create a random key
+        seed = random.randint(0, 2**32 - 1)
+        self.key = jax.random.PRNGKey(seed)
+
+    def p_generate(
+        self, tokenized_prompt, key, top_k, top_p, temperature, condition_scale
+    ):
+        return self.model.generate(
+            **tokenized_prompt,
+            prng_key=key,
+            params=self.params,
+            top_k=top_k,
+            top_p=top_p,
+            temperature=temperature,
+            condition_scale=condition_scale,
+        )
+
+    def p_decode(self, indices):
+        return self.vqgan.decode_code(indices, params=self.vqgan_params)
+
+    def generate_image(self,
+                       prompt: str,
+                       output_path: str,
+                       top_k=None,
+                       top_p=None,
+                       temperature=None,
+                       condition_scale: float = 10.0):
+
+        prompts = [prompt]
+        logger.debug(f"Prompts: {prompts}\n")
+        tokenized_prompt = self.processor(prompts)
+
+        # get a new key
+        self.key, subkey = jax.random.split(self.key)
+        # generate images
+        logger.debug("Generating encoded image...")
+        encoded_images = self.p_generate(
+            tokenized_prompt,
+            subkey,
+            top_k,
+            top_p,
+            temperature,
+            condition_scale
+        )
+
+        # remove BOS
+        encoded_images = encoded_images.sequences[..., 1:]
+        # decode images
+        logger.debug("Decoding encoded image...")
+        decoded_images = self.p_decode(encoded_images)
+        decoded_images = decoded_images.clip(0.0, 1.0).reshape((-1, 256, 256, 3))
+        img = Image.fromarray(np.asarray(decoded_images[0] * 255, dtype=np.uint8))
+
+        filename = os.path.join(output_path, 'result.jpg')
+        img.save(filename)
+        logger.debug(f"Done. Saved image to {filename}")
+
+        return filename
+
+
+if __name__ == "__main__":
+    dalle = DalleMini(
+        "/home/dilith/Projects/wave-image-styler/models/dalle-mini",
+        "/home/dilith/Projects/wave-image-styler/models/vqgan_imagenet_f16_16384"
+    )
+    prompt = "sunset over a lake in the mountains"
+    image_path = dalle.generate_image(prompt, "")

--- a/img_styler/image_prompt/dalle_mini_model.py
+++ b/img_styler/image_prompt/dalle_mini_model.py
@@ -1,5 +1,6 @@
 # Reference: https://colab.research.google.com/github/borisdayma/dalle-mini/blob/main/tools/inference/inference_pipeline.ipynb#scrollTo=sOtoOmYsSYPz
 
+import gc
 import os
 import toml
 from pathlib import Path
@@ -88,6 +89,7 @@ class DalleMini:
         filename = os.path.join(output_path, 'result.jpg')
         img.save(filename)
         logger.debug(f"Done. Saved image to {filename}")
+        gc.collect()
 
         return filename
 

--- a/img_styler/ui/common.py
+++ b/img_styler/ui/common.py
@@ -74,9 +74,8 @@ async def update_processed_face(q: Q, save=False):
             order=2,
         )
         if q.client.task_choice == "D":
-            q.page["prompt_form"] = ui.form_card(
-                ui.box("main", order=1, height="320px", width="980px"),
-                items=[
+            if q.client.prompt_model == 'prompt_sd':
+                items = [
                     ui.inline(
                         items=[
                             ui.checkbox(
@@ -88,13 +87,9 @@ async def update_processed_face(q: Q, save=False):
                             ),
                             ui.button(name="prompt_apply", label="Apply"),
                         ]
-                    ),
-                    ui.textbox(
-                        name="prompt_textbox",
-                        label="Prompt",
-                        multiline=True,
-                        value=q.client.prompt_textbox,
-                    ),
+                    )
+                ]
+                extra_settings = [
                     ui.textbox(
                         name="negative_prompt_textbox",
                         label="Do not include",
@@ -140,8 +135,58 @@ async def update_processed_face(q: Q, save=False):
                                 tooltip="No of steps for image synthesis.",
                             ),
                         ],
-                    ),
-                ],
+                    )
+                ]
+            else:
+                items = [
+                    ui.button(name="prompt_apply", label="Apply")
+                ]
+                extra_settings = [
+                    ui.expander(
+                        name="expander",
+                        label="Settings",
+                        items=[
+                            ui.textbox(
+                                name="prompt_seed",
+                                label="Seed",
+                                value=str(q.client.prompt_seed),
+                            ),
+                            ui.textbox(
+                                name="prompt_top_k",
+                                label="Top-K",
+                                value=str(q.client.prompt_top_k),
+                            ),
+                            ui.textbox(
+                                name="prompt_top_p",
+                                label="Top-P",
+                                value=str(q.client.prompt_top_p),
+                            ),
+                            ui.textbox(
+                                name="prompt_temp",
+                                label="Temperature",
+                                value=str(q.client.prompt_temp),
+                            ),
+                            ui.slider(
+                                name="prompt_cond_scale",
+                                label="Condition Scale",
+                                min=1,
+                                max=20,
+                                value=q.client.prompt_cond_scale,
+                                tooltip="Higher the value, the closer the result is to the prompt (less diversity).",
+                            ),
+                        ],
+                    )
+                ]
+            q.page["prompt_form"] = ui.form_card(
+                ui.box("main", order=1, height="320px", width="980px"),
+                items=items + [
+                    ui.textbox(
+                        name="prompt_textbox",
+                        label="Prompt",
+                        multiline=True,
+                        value=q.client.prompt_textbox,
+                    )
+                ] + extra_settings
             )
     if save:
         await q.page.save()

--- a/img_styler/ui/components.py
+++ b/img_styler/ui/components.py
@@ -62,10 +62,10 @@ def get_user_title(q: Q):
 
 def get_controls(q: Q):
     task_choices = [
-        ui.choice("A", "Fix Resolution"),
+        ui.choice("A", "Image Restoration"),
         ui.choice("B", "Image Styling"),
         ui.choice("C", "Image Editing"),
-        ui.choice("D", "Image prompt"),
+        ui.choice("D", "Image Prompt"),
     ]
     task_choice_dropdown = ui.dropdown(
         name="task_dropdown",
@@ -75,7 +75,7 @@ def get_controls(q: Q):
         trigger=True,
         choices=task_choices,
         tooltip="There are few options available. \
-            Fix Resolution (Increase resolution and fix artifacts in an existing image), \
+            Image Restoration (Increase resolution and fix artifacts in an existing image), \
             Image Styling (Transfer a style to an original image), \
             Image Editing (Edit and transform an existing image), and \
             Image Prompt (Generate image via prompt)",
@@ -211,7 +211,7 @@ def get_controls(q: Q):
             value=q.client.yaw if q.client.yaw else 0,
         ),
     ]
-    if q.client.task_choice == "A":  # Fix Resolution
+    if q.client.task_choice == "A":  # Image Restoration
         img_name_parts = q.client.source_face.split("/")[-1].split(".")
         new_img_name = ".".join(img_name_parts[:-1]) + "_fixed." + img_name_parts[-1]
         disabled = q.client.processedimg is None
@@ -240,7 +240,7 @@ def get_controls(q: Q):
                     justify="end",
                 ),
                 ui.buttons(
-                    [ui.button("fix_resolution", "Fix Resolution", primary=True)],
+                    [ui.button("img_restoration", "Image Restoration", primary=True)],
                     justify="end",
                 ),
                 ui.separator(),
@@ -447,7 +447,7 @@ def get_controls(q: Q):
                     tooltip="There are few options available. \
                         Image Styling (Transfer a style to an original image), \
                         Image Editing (Edit and transform an existing image), and \
-                        Fix Resolution (Increase resolution and fix artifacts in an existing image), and \
+                        Image Restoration (Increase resolution and fix artifacts in an existing image), and \
                         Image Prompt (Generate image via prompt)",
                 ),
                 ui.dropdown(

--- a/img_styler/ui/components.py
+++ b/img_styler/ui/components.py
@@ -478,6 +478,19 @@ def get_controls(q: Q):
                     ],
                     justify="end",
                 ),
+                ui.separator(),
+                ui.dropdown(
+                    name="prompt_model",
+                    label="Model",
+                    choices=[
+                        ui.choice(name='prompt_sd', label="Stable Diffusion"),
+                        ui.choice(name='prompt_dalle_mini', label="DALL-E mini"),
+                    ],
+                    value=q.client.prompt_model,
+                    trigger=True,
+                    tooltip="Select a model to use for prompting.",
+                ),
+            ] + ([
                 ui.choice_group(
                     name="choice_group_prompt",
                     label="Options",
@@ -494,7 +507,7 @@ def get_controls(q: Q):
                     ],
                     tooltip="Stable Diffusion is a text-to-image latent diffusion model created by the researchers and engineers from CompVis, Stability AI and LAION.",
                 ),
-            ],
+            ] if q.client.prompt_model == 'prompt_sd' else [])
         )
 
 

--- a/img_styler/ui/components.py
+++ b/img_styler/ui/components.py
@@ -459,6 +459,7 @@ def get_controls(q: Q):
                     ],
                     value=q.client.source_face,
                     trigger=True,
+                    disabled=(q.client.prompt_model == "prompt_dalle_mini"),
                     tooltip="Select a source image for editing. One can upload a new source image as well.",
                 ),
                 ui.buttons(

--- a/img_styler/ui/handlers.py
+++ b/img_styler/ui/handlers.py
@@ -275,16 +275,20 @@ async def image_upload(q: Q):
     await q.page.save()
 
 
+def check_input_value(value: str, val_type, default=None):
+    try:
+        return val_type(value)
+    except ValueError:
+        return default
+
+
 @on("prompt_apply")
 async def prompt_apply(q: Q):
     logger.info("Enable prompt.")
     logger.info(f"Prompt value: {q.args.prompt_textbox}")
     random_seed = random.randint(600000000000000, 700000000000000)
 
-    if str(q.args.prompt_seed) != "None":
-        random_seed = int(q.args.prompt_seed)
-    else:
-        q.args.prompt_seed = random_seed
+    random_seed = q.args.prompt_seed = check_input_value(q.args.prompt_seed, int, random_seed)
     if q.client.prompt_model == 'prompt_sd':
         logger.info(f"Number of steps: {q.args.diffusion_n_steps}")
         logger.info(f"Guidance scale: {q.args.prompt_guidance_scale}")
@@ -324,9 +328,9 @@ async def prompt_apply(q: Q):
             prompt=q.args.prompt_textbox,
             output_path=OUTPUT_PATH,
             seed=random_seed,
-            top_k=None if q.args.prompt_top_k == 'None' else int(q.args.prompt_top_k),
-            top_p=None if q.args.prompt_top_p == 'None' else float(q.args.prompt_top_k),
-            temperature=None if q.args.prompt_temp == 'None' else float(q.args.prompt_temp),
+            top_k=check_input_value(q.args.prompt_top_k, int),
+            top_p=check_input_value(q.args.prompt_top_p, float),
+            temperature=check_input_value(q.args.prompt_temp, float),
             condition_scale=q.args.prompt_cond_scale,
         )
 

--- a/img_styler/ui/handlers.py
+++ b/img_styler/ui/handlers.py
@@ -90,7 +90,7 @@ async def process(q: Q):
         style_type = q.client.source_style[len("style_") :]
         q.client.gif_path = generate_gif(q.client.source_face, 15, style_type)
     out_path = os.path.join(OUTPUT_PATH, "temp.png")
-    if q.args.fix_resolution and (q.client.processedimg or q.client.source_face):
+    if q.args.img_restoration and (q.client.processedimg or q.client.source_face):
         q.client.restorer = q.client.restorer or init_gfpgan()
         img_path = q.client.processedimg or q.client.source_face
         q.client.processedimg = out_path

--- a/img_styler/ui/initializers.py
+++ b/img_styler/ui/initializers.py
@@ -30,8 +30,10 @@ async def custom_client_init(q: Q):
     q.client.z_low = 7
     q.client.z_high = 14
     q.client.diffusion_n_steps = 50
+    q.client.prompt_model = 'prompt_sd'
     q.client.prompt_guidance_scale = 7.5
     q.client.prompt_use_source_img = True
+    q.client.prompt_cond_scale = 10
 
 
 async def initialize_app(q: Q):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ click==8.1.3; python_version >= "3.7" and python_full_version >= "3.7.1"
 cmake==3.22.2
 colorama==0.4.5; sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.7.1" and platform_system == "Windows"
 cycler==0.11.0; python_version >= "3.7"
+dalle-mini
 deepface==0.0.73; python_full_version >= "3.5.5"
 dlib==19.24.0
 facexlib>=0.2.5
@@ -22,6 +23,7 @@ fonttools==4.37.1; python_version >= "3.7"
 ftfy ==6.1.1
 gast==0.4.0; python_version >= "3.7" and python_full_version >= "3.5.5"
 gdown==4.5.1; python_full_version >= "3.5.5"
+git+https://github.com/patil-suraj/vqgan-jax.git
 google-auth-oauthlib==0.4.6; python_version >= "3.7" and python_full_version >= "3.5.5"
 google-auth==2.11.0; python_version >= "3.7" and python_full_version >= "3.6.0"
 google-pasta==0.2.0; python_version >= "3.7" and python_full_version >= "3.5.5"


### PR DESCRIPTION
This PR enables the `mini` version of the [DALL-E mini](https://huggingface.co/dalle-mini/dalle-mini) model available here. I will add the additional setting-up steps to the Wiki, once the PR is merged.

Instructions for setting up the files for DALL-E mini:
```
cd models
git clone https://huggingface.co/dalle-mini/dalle-mini
cd dalle-mini
git lfs pull

cd ..
git clone https://huggingface.co/dalle-mini/vqgan_imagenet_f16_16384
cd vqgan_imagenet_f16_16384
git lfs pull
```

The left side panel now looks as follows. The default option for `Model` is `Stable Diffusion` which includes the previously available radio buttons.
![image](https://user-images.githubusercontent.com/54039395/206865037-b1860d04-5dc7-4653-a91d-52e2a9351d33.png)

In addition to the `seed` the following settings are supported:
![image](https://user-images.githubusercontent.com/54039395/206864395-b1ff2c91-c7f9-4766-ab83-db9be5823a27.png)
